### PR TITLE
fix(ssh): sanitize stdout with delimiter to support custom dotfiles

### DIFF
--- a/lib/service/ssh_service.dart
+++ b/lib/service/ssh_service.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 import 'dart:async';
 import 'package:dartssh2/dartssh2.dart';
 import 'dart:io';
+import 'dart:convert';
 
 class SSHService {
   SSHClient? client;
@@ -67,8 +68,11 @@ class SSHService {
   }
 
   Future<String> runCommand(String command) async {
-    final result = await _safe(() => client!.run(command));
-    return String.fromCharCodes(result);
+    final marker = 'SUDOSYNC_DATA_START';
+    final fullCommand = 'echo "$marker"; $command';
+    final session = await _safe(() => client!.execute(fullCommand));
+    final rawOutput = await session.stdout.cast<List<int>>().transform(utf8.decoder).join();
+    return rawOutput.contains(marker) ? rawOutput.split(marker).last.trim() : rawOutput.trim();
   }
 
   Future<String> run(String s) async {


### PR DESCRIPTION
## **Description:**
This PR resolves a critical parsing bug where the SudoSync app fails to display System Monitor stats (like Memory and CPU usage) when connecting to a Linux server that has customized terminal startup scripts (e.g., `fastfetch`, `neofetch`, or custom `echo` statements in `.bashrc`/`.zshrc`).

It also patches a Dart stream type mismatch error when decoding SSH `stdout`.

## **The Root Cause**
Previously, when SudoSync executed a background command like `free -h`, it expected to receive *only* the raw stats back. However, if a user has terminal "ricing" configured, those background tools print massive amounts of text directly to `stdout`. The app's parser was receiving a giant block of ASCII art merged with the actual system stats, causing it to fail to find the numbers needed for the UI.

## **The Solution: The Delimiter Strategy**
To guarantee we only parse the exact data SudoSync requests without forcing users to disable their custom `.bashrc` setups, this PR introduces a "Delimiter Strategy" to the `runCommand` function.

1. **Type Fix:** Added `.cast<List<int>>()` to the `session.stdout` stream before transforming it with `utf8.decoder` to resolve a Dart compiler mismatch between `Uint8List` and `List<int>`.
2. **The Marker:** Injected a unique, invisible marker (`SUDOSYNC_DATA_START`) directly before the intended command.
3. **The Slicer:** When the raw stream comes back, the code checks for the marker, splits the string exactly at the marker, and returns only the clean data that comes *after* it.

This creates a perfectly clean "data pipe." It allows the user's server to print custom background ASCII art, while guaranteeing SudoSync's UI parser only ever sees the isolated, clean system stats it expects. It does not affect the interactive Terminal UI, as that correctly utilizes a separate PTY shell allocation.

## **Testing Performed:**

* [x] Tested via Dart CLI script to verify stream splitting and UI payload isolation.
* [x] Tested on physical Android device (via Wireless ADB) connecting to a customized Fedora Wayland host.
* [x] Verified System Monitor UI successfully parses Memory/Battery stats.

During debugging, I tested the three approaches initially proposed in the issue. However, none of them provided a robust solution for a diverse user base, particularly for users with heavily customized dotfiles.
Because we cannot control what shell a user runs, and we cannot reliably suppress their custom login scripts over a standard SSH Exec channel, the only guaranteed way to get clean data is to isolate it.
By injecting echo `"SUDOSYNC_DATA_START";` directly before our target command, we allow the server to print as much background noise as it wants. We then slice the stream at our unique marker, completely bypassing the need to fight the user's environment variables or shell preferences.